### PR TITLE
Quotes are required for strings

### DIFF
--- a/configuration.html
+++ b/configuration.html
@@ -96,8 +96,8 @@
   
   
   <div class="code"><pre>[hockeypuck]
-contact=0xF79362DA44A2D1DB
-hostname=keys.cmarstech.com</pre></div>
+contact="F79362DA44A2D1DB"
+hostname="keys.cmarstech.com"</pre></div>
   
 
   


### PR DESCRIPTION
When trying to set up a hockeypuck keyserver according to the instructions, it failed with errors along the lines of
```
Near line 7 (last key parsed 'hockeypuck.contact'): expected value but found "x" instead
```
Changing the example to reflect this.