### PR TITLE
Refer to hockeypuck.io

### DIFF
--- a/1x.html
+++ b/1x.html
@@ -92,7 +92,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io" target="_blank">https://hockeypuck.github.io</a></p>
+<p class="link"><a href="https://hockeypuck.io" target="_blank">https://hockeypuck.io</a></p>
           </div>
         
       </div>

--- a/community.html
+++ b/community.html
@@ -166,7 +166,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/configuration.html
+++ b/configuration.html
@@ -425,7 +425,7 @@ path=&#34;/path/to/prefix/tree&#34;</pre></div>
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/contributing.html
+++ b/contributing.html
@@ -323,7 +323,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/dumping.html
+++ b/dumping.html
@@ -102,7 +102,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/index.html
+++ b/index.html
@@ -281,7 +281,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io" target="_blank">https://hockeypuck.github.io</a></p>
+<p class="link"><a href="https://hockeypuck.io" target="_blank">https://hockeypuck.io</a></p>
           </div>
         
       </div>

--- a/install-docker.html
+++ b/install-docker.html
@@ -127,7 +127,7 @@ docker-compose build</pre></div>
     Casey Marshall, Marcel Waldvogel
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/install-source.html
+++ b/install-source.html
@@ -175,7 +175,7 @@ go install github.com/hockeypuck/server/cmd/hockeypuck-pbuild</pre></div>
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/install-tarball.html
+++ b/install-tarball.html
@@ -163,7 +163,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/install-ubuntu.html
+++ b/install-ubuntu.html
@@ -207,7 +207,7 @@ sudo apt-get update</pre></div>
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/juju.html
+++ b/juju.html
@@ -515,7 +515,7 @@ juju deploy cs:~hockeypuck/trusty/hockeypuck hkp2</pre></div>
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/populating.html
+++ b/populating.html
@@ -115,7 +115,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>

--- a/pre-populating.html
+++ b/pre-populating.html
@@ -115,7 +115,7 @@
     Casey Marshall
   </p>
   
-<p class="link"><a href="https://hockeypuck.github.io/" target="_blank">https://hockeypuck.github.io/</a></p>
+<p class="link"><a href="https://hockeypuck.io/" target="_blank">https://hockeypuck.io/</a></p>
           </div>
         
       </div>


### PR DESCRIPTION
The page footers still referred to hockeypuck.github.io