### PR TITLE
Removing references to mongoDB

### DIFF
--- a/contributing.html
+++ b/contributing.html
@@ -55,7 +55,6 @@
   <ul>
     <li><a href="https://gopkg.in/hockeypuck/conflux.v2" target="_blank">conflux</a> Reconciliation protocol used for peering.</li>
     <li><a href="https://gopkg.in/hockeypuck/hkp.v1" target="_blank">hkp</a> HKP protocol handler.</li>
-    <li><a href="https://gopkg.in/hockeypuck/mgohkp.v1" target="_blank">mgohkp</a> MongoDB storage driver.</li>
     <li><a href="https://gopkg.in/hockeypuck/openpgp.v1" target="_blank">openpgp</a> OpenPGP public key data model &amp; processing. </li>
     <li><a href="https://gopkg.in/hockeypuck/pghkp.v1" target="_blank">pghkp</a> PostgreSQL JSONB storage driver.</li>
   </ul>

--- a/index.html
+++ b/index.html
@@ -66,7 +66,7 @@
   </p>
   <h2 id="TOC_3.3.">3.3. Modular storage backend</h2>
   <p>
-    Hockeypuck may use either MongoDB or PostgreSQL 9.4 for storing indexed key
+    Hockeypuck uses PostgreSQL ≥ 9.4 for storing indexed key
     material. The architecture supports additional storage backends, which must
     implement a simple set of Go interfaces.
   </p>

--- a/install-ubuntu.html
+++ b/install-ubuntu.html
@@ -36,33 +36,27 @@
           </div>
   <h1 id="TOC_1.">1. Install on Ubuntu Server</h1>
   <h1 id="TOC_2.">2. Prerequisites</h1>
-  <h2 id="TOC_2.1.">2.1. Ubuntu 14.04</h2>
+  <h2 id="TOC_2.1.">2.1. Ubuntu 20.04</h2>
   <p>
-    The latest LTS is recommended. Hockeypuck 2.0 is currently packaged for trusty.
+    The latest LTS is recommended. Hockeypuck 2.0 is currently packaged for bionic.
   </p>
-  <h1 id="TOC_3.">3. Add the unstable Hockeypuck PPA</h1>
-  <div class="code"><pre>sudo apt-add-repository ppa:hockeypuck/unstable
+  <h1 id="TOC_3.">3. Add the daily Hockeypuck PPA</h1>
+  <div class="code"><pre>sudo apt-add-repository ppa:hockeypuck/daily
 sudo apt-get update</pre></div>
   <h1 id="TOC_4.">4. Install the database of your choice</h1>
   <p>
     If you plan on connecting to a local database on the same server, install it now:
   </p>
   <p>
-    MongoDB:
+  PostgreSQL ≥ 9.4:
   </p>
-  <div class="code"><pre>sudo apt-get install mongodb-server</pre></div>
-  <p>
-    PostgreSQL 9.4:
-  </p>
-  <p>
-    Get it from the PostgreSQL <a href="http://www.postgresql.org/download/linux/ubuntu/" target="_blank">Apt repository for LTS distributions</a>.
-  </p>
+  <div class="code"><pre>sudo apt install postgresql</pre></div>
   <h1 id="TOC_5.">5. Install Hockeypuck</h1>
-  <div class="code"><pre>sudo apt-get install hockeypuck</pre></div>
+  <div class="code"><pre>sudo apt install hockeypuck</pre></div>
   <h1 id="TOC_6.">6. Configure Hockeypuck</h1>
   <p>
-    Edit the <a href="configuration.html" target="_self">configuration</a> file <code>/etc/hockeypuck/hockeypuck.conf</code>.  
-    Basic templates for mongoDB and PostgreSQL are provided, and should be copied to <code>/etc/hockeypuck/hockeypuck.conf</code>
+    Edit the <a href="configuration.html" target="_self">configuration</a> file <code>/etc/hockeypuck/hockeypuck.conf</code>.
+    Basic templates for PostgreSQL are provided, and should be copied to <code>/etc/hockeypuck/hockeypuck.conf</code>
     and edited to suit your needs, and to add any remote peers.
   </p>
   <h1 id="TOC_7.">7. Running from user-space (optional)</h1>
@@ -90,4 +84,4 @@ sudo apt-get update</pre></div>
       </div>
     </div>
   </body>
-</html>
+  </html>

--- a/populating.html
+++ b/populating.html
@@ -32,9 +32,6 @@
     your Hockeypuck instance to share as many public keys with prospective peers as
     possible before joining a pool of synchronizing key servers.
   </p>
-  <p>
-    The process is the same whether using MongoDB or PostgreSQL storage drivers.
-  </p>
   <h2 id="TOC_1.1.">1.1. Fetch a dump of recent keyfiles</h2>
   <p>
     In Hockeypuck development and testing, I&#39;ve used the sources listed at

--- a/pre-populating.html
+++ b/pre-populating.html
@@ -32,9 +32,6 @@
     to pre-populate your Hockeypuck instance to share as many public keys 
     with prospective peers as possible before joining a pool of synchronizing key servers.
   </p>
-  <p>
-    The process is the same whether using MongoDB or PostgreSQL storage drivers.
-  </p>
   <h2 id="TOC_1.1.">1.1. Fetch a dump of recent keyfiles</h2>
   <p>
     In Hockeypuck development and testing, I&#39;ve used the sources listed at


### PR DESCRIPTION
As suggested in a comment to #11, the documentation still mentions MongoDB. However, due to restrictive permissions, I was unable to accept that change.

With the exception of Juju, which I have no experience with and seems to require MongoDB, I have removed any references.

I also tried to adapt the `install-ubuntu` instructions, but would like feedback on those (as mentioned elsewhere, I however doubt that I can make modifications to my branch later; the permissions on this seem to be unusually restrictive.)