### PR TITLE
Document use of pbuild

### DIFF
--- a/populating.html
+++ b/populating.html
@@ -42,11 +42,13 @@
   </p>
   <h2 id="TOC_1.2.">1.2. Stop the Hockeypuck service</h2>
   <h2 id="TOC_1.3.">1.3. Load keyfiles</h2>
-  <div class="code"><pre>hockeypuck-load -config /etc/hockeypuck/hockeypuck.conf /path/to/keyfiles/\*.pgp</pre></div>
+  <div class="code"><pre>hockeypuck-load -config /etc/hockeypuck/hockeypuck.conf /path/to/keyfiles/\*.pgp
+hockeypuck-pbuild -config /etc/hockeypuck/hockeypuck.conf</pre></div>
   <p>
     If you installed from PPA on Ubuntu, you&#39;ll want to do this as the <code>hockeypuck</code> user:
   </p>
-  <div class="code"><pre>su - hockeypuck -c &#39;hockeypuck-load -config /etc/hockeypuck/hockeypuck.conf /path/to/keyfiles/\*.pgp&#39;</pre></div>
+  <div class="code"><pre>su - hockeypuck -c &#39;hockeypuck-load -config /etc/hockeypuck/hockeypuck.conf /path/to/keyfiles/\*.pgp; \
+hockeypuck-pbuild -config /etc/hockeypuck/hockeypuck.conf&#39;</pre></div>
   <h2 id="TOC_1.4.">1.4. Start the Hockeypuck service</h2>
         <h2>Authors</h2>
           <div class="author">


### PR DESCRIPTION
After `hockeypuck-load`, `hockeypuck-pbuild` should also be run. Document this.