### PR TITLE
Updated KeydumpSources URL

### DIFF
--- a/populating.html
+++ b/populating.html
@@ -38,7 +38,7 @@
   <h2 id="TOC_1.1.">1.1. Fetch a dump of recent keyfiles</h2>
   <p>
     In Hockeypuck development and testing, I&#39;ve used the sources listed at
-    <a href="https://bitbucket.org/skskeyserver/sks-keyserver/wiki/KeydumpSources" target="_blank">bitbucket.org/skskeyserver/sks-keyserver/wiki/KeydumpSources</a>.
+    <a href="https://github.com/SKS-Keyserver/sks-keyserver/wiki/KeydumpSources" target="_blank">github.com/SKS-Keyserver/sks-keyserver/wiki/KeydumpSources</a>.
   </p>
   <h2 id="TOC_1.2.">1.2. Stop the Hockeypuck service</h2>
   <h2 id="TOC_1.3.">1.3. Load keyfiles</h2>


### PR DESCRIPTION
SKS moved from Bitbucket to GitHub.